### PR TITLE
Improve layout of mascot lists

### DIFF
--- a/themes/bandarlog/layouts/_default/baseof.html
+++ b/themes/bandarlog/layouts/_default/baseof.html
@@ -24,30 +24,7 @@
   </head>
   <body class="{{ .Section | default "special" }}-{{ .Kind }}">
     <div class="topmenu" id="main-menu" role="navigation" aria-expanded="false" aria-label="Main menu">
-      <nav class="pure-menu pure-menu-horizontal">
-        <ul class="pure-menu-list action-list">
-          <li class="pure-menu-item menu-toggle">
-            <a href="#main-menu" class="pure-menu-link" role="button" id="main-menu-toggle" aria-controls="main-menu" aria-label="Open main menu">
-              <span class="sr-only">Open main menu</span>
-              <span class="fas fa-bars fa-fw" aria-hidden="true"></span>
-            </a>
-          </li>
-          <li class="pure-menu-item menu-close">
-            <a href="#" class="pure-menu-link" role="button" id="main-menu-close" aria-controls="main-menu" aria-label="Close main menu">
-              <span class="sr-only">Close main menu</span>
-              <span class="fas fa-times fa-fw" aria-hidden="true"></span>
-            </a>
-          </li>
-        </ul>
-        <p class="pure-menu-heading"><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></p>
-      </nav>
-      <nav class="pure-menu collapsible-menu">
-        <ul class="pure-menu-list">
-          {{- range .Site.Menus.main }}
-          <li class="pure-menu-item{{if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} pure-menu-selected{{end}}"><a class="pure-menu-link" href="{{ .URL }}">{{ .Name }}</a></li>
-          {{- end }}
-        </ul>
-      </nav>
+      {{ partial "main-menu.html" . }}
     </div>
 
     <div class="article"><div class="header">

--- a/themes/bandarlog/layouts/_default/baseof.html
+++ b/themes/bandarlog/layouts/_default/baseof.html
@@ -23,18 +23,21 @@
     {{- end }}
   </head>
   <body class="{{ .Section | default "special" }}-{{ .Kind }}">
-    <div class="topmenu" id="main-menu" role="navigation" aria-expanded="false" aria-label="Main menu">
+    <div class="topmenu" id="main-menu" role="navigation" aria-expanded="false" aria-label="Main menu"><div class="container">
       {{ partial "main-menu.html" . }}
-    </div>
-
-    <div class="article"><div class="header">
-      {{- block "header" . }}{{ end -}}
-    </div><div class="content">
-      {{- block "content" . }}{{ end -}}
     </div></div>
 
+    <div class="article">
+      <div class="header"><div class="container">
+      {{- block "header" . }}{{ end -}}
+      </div></div>
+      <div class="content"><div class="container">
+      {{- block "content" . }}{{ end -}}
+      </div></div>
+    </div>
+
     {{- block "footer" . }}
-    <div class="footer">
+    <div class="footer"><div class="container">
       <p>
         {{- if .IsPage }}
         <i class="fa fa-calendar" title="Posted on"></i> <time datetime="{{ .Date }}">{{ .Date.Format "Monday, 2 January 2006" }}</time>.
@@ -44,7 +47,7 @@
         <i class="fas fa-server" title="Hosted on"></i> <a href="https://www.netlify.com/">Netlify</a>.
         <i class="fas fa-code-branch" title="Fork on"></i> <a href="https://github.com/sparksp/bandarlog.co.uk/">GitHub</a>.
       </p>
-    </div>
+    </div></div>
     {{- end }}
 
     {{ if ne .Site.GoogleAnalytics "off" }}

--- a/themes/bandarlog/layouts/index.html
+++ b/themes/bandarlog/layouts/index.html
@@ -9,7 +9,7 @@
 {{ end }}
 {{ define "content" }}
     <div class="mascot-list">
-        {{- range (where .Data.Pages "Section" "mascot") | first 3 }}
+        {{- range (where .Data.Pages "Section" "mascot") | first 2 }}
         {{- $page := . }}
         {{- range .Resources.ByType "image" | first 1 }}
         {{ partial "mascot-item.html" (dict "page" $page "image" . )}}

--- a/themes/bandarlog/layouts/partials/main-menu.html
+++ b/themes/bandarlog/layouts/partials/main-menu.html
@@ -1,0 +1,24 @@
+<nav class="pure-menu pure-menu-horizontal">
+  <ul class="pure-menu-list action-list">
+    <li class="pure-menu-item menu-toggle">
+      <a href="#main-menu" class="pure-menu-link" role="button" id="main-menu-toggle" aria-controls="main-menu" aria-label="Open main menu">
+        <span class="sr-only">Open main menu</span>
+        <span class="fas fa-bars fa-fw" aria-hidden="true"></span>
+      </a>
+    </li>
+    <li class="pure-menu-item menu-close">
+      <a href="#" class="pure-menu-link" role="button" id="main-menu-close" aria-controls="main-menu" aria-label="Close main menu">
+        <span class="sr-only">Close main menu</span>
+        <span class="fas fa-times fa-fw" aria-hidden="true"></span>
+      </a>
+    </li>
+  </ul>
+  <p class="pure-menu-heading"><a href="{{ "/" | relURL }}">{{ .Site.Title }}</a></p>
+</nav>
+<nav class="pure-menu collapsible-menu">
+  <ul class="pure-menu-list">
+    {{- range .Site.Menus.main }}
+    <li class="pure-menu-item{{if or ($.IsMenuCurrent "main" .) ($.HasMenuCurrent "main" .) }} pure-menu-selected{{end}}"><a class="pure-menu-link" href="{{ .URL }}">{{ .Name }}</a></li>
+    {{- end }}
+  </ul>
+</nav>

--- a/themes/bandarlog/layouts/partials/main-menu.html
+++ b/themes/bandarlog/layouts/partials/main-menu.html
@@ -1,5 +1,5 @@
 <nav class="pure-menu pure-menu-horizontal">
-  <ul class="pure-menu-list action-list">
+  <ul class="pure-menu-list action-list pull-left">
     <li class="pure-menu-item menu-toggle">
       <a href="#main-menu" class="pure-menu-link" role="button" id="main-menu-toggle" aria-controls="main-menu" aria-label="Open main menu">
         <span class="sr-only">Open main menu</span>

--- a/themes/bandarlog/static/css/bandarlog.css
+++ b/themes/bandarlog/static/css/bandarlog.css
@@ -23,6 +23,13 @@ body {
     padding: 0 1em;
 }
 
+.container {
+    margin-left: auto;
+    margin-right: auto;
+    width: auto;
+    max-width: 64em;
+}
+
 .topmenu {
     background-color: rgba(255, 255, 255, .9);
     border-bottom: 1px solid rgba(0, 0, 0, .3);

--- a/themes/bandarlog/static/css/bandarlog.css
+++ b/themes/bandarlog/static/css/bandarlog.css
@@ -126,7 +126,7 @@ body {
     padding: 1px 1em;
 }
 
-.special-home .content, .mascot-section .content,
+.special-home .content, .mascot-section .content, .tags-taxonomy .content,
 .mascot-page .content, .special-404 .content {
     padding: 0;
 }

--- a/themes/bandarlog/static/css/bandarlog.css
+++ b/themes/bandarlog/static/css/bandarlog.css
@@ -67,6 +67,11 @@ body {
 
 .collapsible-menu {
     font-size: 0;
+    position: absolute;
+    width: 100%;
+    background-color: rgba(255, 255, 255, .9);
+    border: 1px solid rgba(0, 0, 0, .3);
+    border-top: none;
 }
 :target .collapsible-menu, [aria-expanded="true"] .collapsible-menu {
     font-size: 1em;

--- a/themes/bandarlog/static/css/bandarlog.css
+++ b/themes/bandarlog/static/css/bandarlog.css
@@ -3,23 +3,23 @@ html {
 }
 body {
     display: flex;
-    flex-flow: column;
+    flex: auto;
+    flex-direction: column;
     min-height: 100%;
 }
 .topmenu {
-    flex: 0 1 auto;
     position: -webkit-sticky;
     position: sticky;
     top: 0;
 }
 .article {
-    flex: 1 1 auto;
+    flex: auto;
 }
 .header, .content {
     padding: 0 1em;
 }
 .footer {
-    flex: 0 1 2em;
+    flex-basis: 2em;
     padding: 0 1em;
 }
 
@@ -104,6 +104,7 @@ body {
     padding: 1px 1em;
 }
 
+.special-home .content, .mascot-section .content,
 .mascot-page .content, .special-404 .content {
     padding: 0;
 }
@@ -122,12 +123,14 @@ body {
 }
 
 .mascot-list {
-    text-align: center;
-    margin: 1em 0;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    padding: .5em;
 }
 .mascot-item {
-    display: inline-block;
-    margin: .5em;
+    break-inside: avoid;
+    padding: .5em;
 }
 .mascot-link {
     background-color: rgba(255, 255, 255, .8);

--- a/themes/bandarlog/static/css/bandarlog.css
+++ b/themes/bandarlog/static/css/bandarlog.css
@@ -35,12 +35,22 @@ body {
     border-bottom: 1px solid rgba(0, 0, 0, .3);
     color: black;
 }
+.topmenu .container {
+    position: relative;
+}
+.topmenu .pull-left {
+    position: absolute;
+    left: 0;
+    top: 0;
+}
 .topmenu .pure-menu-heading {
     font-size: 1em;
     font-weight: bold;
     margin: 0;
-    padding: .5em 1em .5em 0;
+    padding: .5em 0;
+    text-align: center;
     text-transform: none;
+    width: 100%;
 }
 .topmenu a {
     text-decoration: none;


### PR DESCRIPTION
* Fits 3 mascots to a row @ 1024px (iPad)
* Uses `display: flex` to squash spaces between mascots
* Uses `justify-content: space-around` to maintain centered appearance
* Caps layout width at 1024px (64em)
* Centers the site title